### PR TITLE
.vcxprojと.vcxproj.filtersの削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@
 /.vs/CLI2-B/v17/DocumentLayout.json
 /x64/Debug/CLIRPG_B2.exe
 /x64/Debug/CLIRPG_B2.pdb
-/CLIRPG_B2.vcxproj
-/CLIRPG_B2.vcxproj.filters


### PR DESCRIPTION
gitignoreの修正